### PR TITLE
Implement dependency installation in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,8 +9,8 @@ set -e
 ###############################################
 # TODO: Install project dependencies if needed based on relevant config/lock files in the repo.
 # Note that we are developing the project, even if dependencies have been installed before, we need to install again to accommodate the changes we made.
-pip install -r app/requirements.txt
-pip install -r app/test_requirements.txt
+python -m pip install --no-cache-dir -r app/requirements.txt
+python -m pip install --no-cache-dir -r app/test_requirements.txt
 
 export ANSIBLE_LIBRARY=/app/app/library
 export ANSIBLE_MODULE_UTILS=/app/app/library/module_utils
@@ -20,5 +20,6 @@ export ANSIBLE_MODULE_UTILS=/app/app/library/module_utils
 ###############################################
 echo "================= 0909 BUILD START 0909 ================="
 # TODO: Build the project if needed. Note that we are developing the project and making changes to it, even if it has been build before, we need to build it again.
-# <build-commands>
+# This project is pure Python and does not require an explicit build
+# step beyond installing dependencies.
 echo "================= 0909 BUILD END 0909 ================="


### PR DESCRIPTION
## Summary
- update `build.sh` to perform dependency installation only

## Testing
- `./build.sh` *(fails: Could not find a version that satisfies the requirement ansible)*