### PR TITLE
Fix Dockerfile python alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-setuptools \
-    python-is-python3 \
+    && ln -s /usr/bin/python3 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
 ###############################################


### PR DESCRIPTION
## Summary
- remove missing package `python-is-python3`
- create symlink so `python` points to `python3`

## Testing
- `make test_parser`